### PR TITLE
Adds ServerSpec tests via Molecule

### DIFF
--- a/spec/ssl_keys_spec.rb
+++ b/spec/ssl_keys_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+ssl_keypairs = [
+  { 'key' => '/var/lib/prosody/localhost.key',
+    'cert' => '/var/lib/prosody/localhost.crt' }
+]
+ssl_keypairs.each do |ssl_keypair|
+  describe x509_certificate(ssl_keypair['cert']) do
+    it { should be_certificate }
+    it { should be_valid }
+    its(:keylength) { should be >= 2048 }
+    its(:validity_in_days) { should be >= 30 }
+    its(:validity_in_days) { should_not be < 30 }
+  end
+
+  describe x509_private_key(ssl_keypair['key']) do
+    it { should_not be_encrypted }
+    it { should be_valid }
+    it { should have_matching_certificate ssl_keypair['cert'] }
+  end
+end


### PR DESCRIPTION
Adds full suite of serverspec tests for the various Jitsi Meet components:
- jitsi-videobridge
- jicofo
- prosody
- nginx
- ssl keys
- firewall

Using molecule for simplicity; no travis tests yet. (I don't expect this to be an incredibly high-traffic role, and I'm happy to run the tests locally before merging community PRs, if and when they occur.)

Resolves #2. Defers documentation to #1. Also resolves #10.
