### PR TITLE
Adds support for --check mode

### DIFF
--- a/tasks/dynamic_vars.yml
+++ b/tasks/dynamic_vars.yml
@@ -6,6 +6,7 @@
   register: jitsi_meet_videobridge_secret_result
   failed_when: jitsi_meet_videobridge_secret_result.rc != 0 or
                jitsi_meet_videobridge_secret_result.stdout == ''
+  always_run: true
   changed_when: false
 
 - name: Set fact for Jitsi Videobridge secret var.
@@ -21,6 +22,7 @@
     /etc/jitsi/jicofo/config
   register: jitsi_meet_jicofo_secret_result
   changed_when: false
+  always_run: true
   failed_when: jitsi_meet_jicofo_secret_result.rc != 0 or
                jitsi_meet_jicofo_secret_result.stdout == ''
 
@@ -37,6 +39,7 @@
     /etc/jitsi/jicofo/config
   register: jitsi_meet_jicofo_password_result
   changed_when: false
+  always_run: true
   failed_when: jitsi_meet_jicofo_password_result.rc != 0 or
                jitsi_meet_jicofo_password_result.stdout == ''
 

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -14,10 +14,6 @@
     repo: 'deb http://download.jitsi.org/nightly/deb unstable/'
     state: present
 
-- name: Disable MEMPROTECT on Java
-  command: paxctl -cm /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
-  ignore_errors: yes
-
 - name: Install Jitsi Meet
   apt:
     name: jitsi-meet


### PR DESCRIPTION
Permits invocations of `ansible-playbook` with the `--check` flag, essentially a dry run to inspect intended changes without actually changing the state of the server. 

Also snips out the `paxctl` command, deferring to a separate role for managing `paxctld` when running under grsecurity. Will add docs once that role is available.