### PR TITLE
Removes "localhost" config file if using custom SSL keys

### DIFF
--- a/tasks/clean_up_default_configs.yml
+++ b/tasks/clean_up_default_configs.yml
@@ -5,7 +5,7 @@
     state: absent
   notify: restart jitsi-videobridge
 
-- name: Remove Jicofo user config for localhost site
+- name: Remove Jicofo user config for localhost site.
   file:
     path: /var/lib/prosody/auth%2elocalhost
     state: absent
@@ -18,3 +18,17 @@
     path: /etc/prosody/conf.d/localhost.cfg.lua
     state: absent
   notify: restart prosody
+
+  # The "server_names_hash_bucket_size" directive should only occur once in the
+  # Nginx config. If it's duplicated, even only in "available" sites rather than
+  # "enabled", nginx will fail to start. Since this role writes it in a template
+  # when using custom SSL keys, we'll clean up the default localhost file to avoid
+  # duplicating the config line.
+- name: Remove default localhost Nginx config file.
+  file:
+    path: /etc/nginx/sites-available/localhost.conf
+    state: absent
+  notify: restart nginx
+  # Only remove the "localhost" file if we're using custom SSL keys, i.e. in prod.
+  when: jitsi_meet_ssl_cert_path != '' and
+        jitsi_meet_ssl_key_path != ''


### PR DESCRIPTION
The jitsi-meet package will automatically generate a self-signed SSL certificate during installation. This role respects that, but expects admins to supply custom SSL certs issued by a CA. (Therefore if we're using real SSL certs, we'll need to remove the default "localhost" config to avoid duplicating config
lines, which can cause nginx to fail to start.

The role will configure an FQDN-based vhost file, and also accepts a custom string for the field, via `jitsi_meet_server_name`.