### PR TITLE
Supports Chrome browser extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ jitsi_meet_videobridge_port: 5347
 # https://github.com/jitsi/jitsi-meet/pull/427
 jitsi_meet_disable_third_party_requests: true
 
+# Screensharing config for Chrome. You'll need to build and package a browser
+# extension specifically for your domain; see https://github.com/jitsi/jidesha
+jitsi_meet_desktop_sharing_chrome_method: 'ext'
+jitsi_meet_desktop_sharing_chrome_ext_id: 'diibjkoicjeejcmhdnailmkgecihlobk'
+
+# Path to local extension on disk, for copying to target host. The remote filename
+# will be the basename of the path provided here.
+jitsi_meet_desktop_sharing_chrome_extension_filename: ''
+
+# Screensharing config for Firefox. Set max_version to '42' and disabled to 'false'
+# if you want to use screensharing under Firefox.
+jitsi_meet_desktop_sharing_firefox_ext_id: 'null'
+jitsi_meet_desktop_sharing_firefox_disabled: true
+jitsi_meet_desktop_sharing_firefox_max_version_ext_required: '-1'
+
 # These debconf settings represent answers to interactive prompts during installation
 # of the jitsi-meet deb package. If you use custom SSL certs, you may have to set more options.
 jitsi_meet_debconf_settings:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ You'll need to build your own browser extension for Chrome and/or Firefox.
 See the [Jidesha] documentation for detailed build instructions. This role
 has only been tested with custom Chrome extensions.
 
+Chrome forbids installation of extensions from unapproved websites, so you must
+download the `.crx` file directly, then navigate to `chrome://extensions` and
+drag-and-drop the extension to install it. If you want to grant another
+participant screen-sharing support, share the URL for the extension with them
+via the Jitsi Meet text chat pane.
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ jitsi_meet_debconf_settings:
 jitsi_meet_configure_firewall: true
 ```
 
+Screen sharing
+--------------
+Jitsi Meet supports screen sharing functionality via browser extensions.
+Only the party sharing the screen needs the extension installed—other participants
+in the meeting will be able to view the shared screen without installing anything.
+You'll need to build your own browser extension for Chrome and/or Firefox.
+See the [Jidesha] documentation for detailed build instructions. This role
+has only been tested with custom Chrome extensions.
+
 Dependencies
 ------------
 
@@ -155,3 +164,4 @@ Author Information
 [Freedom of the Press Foundation]: https://freedom.press/
 [Molecule]: http://molecule.readthedocs.org/en/master/
 [ServerSpec]: http://serverspec.org/
+[Jidesha]: https://github.com/jitsi/jidesha

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,11 @@ jitsi_meet_videobridge_port: 5347
 # https://github.com/jitsi/jitsi-meet/pull/427
 jitsi_meet_disable_third_party_requests: true
 
+# Screensharing config for Chrome. You'll need to build and package a browser
+# extension specifically for your domain; see https://github.com/jitsi/jidesha
+jitsi_meet_desktop_sharing_chrome_method: 'ext'
+jitsi_meet_desktop_sharing_chrome_ext_id: 'diibjkoicjeejcmhdnailmkgecihlobk'
+
 
 # Screensharing config for Firefox. Set max_version to '42' and disabled to 'false'
 # if you want to use screensharing under Firefox. Separate options are required

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ jitsi_meet_disable_third_party_requests: true
 jitsi_meet_desktop_sharing_chrome_method: 'ext'
 jitsi_meet_desktop_sharing_chrome_ext_id: 'diibjkoicjeejcmhdnailmkgecihlobk'
 
+# Path to local file on disk, for copying to target host. The remote filename
+# will be the basename of the path provided here. Optional.
+jitsi_meet_desktop_sharing_chrome_extension_filename: ''
 
 # Screensharing config for Firefox. Set max_version to '42' and disabled to 'false'
 # if you want to use screensharing under Firefox. Separate options are required

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,14 @@ jitsi_meet_videobridge_port: 5347
 # https://github.com/jitsi/jitsi-meet/pull/427
 jitsi_meet_disable_third_party_requests: true
 
+
+# Screensharing config for Firefox. Set max_version to '42' and disabled to 'false'
+# if you want to use screensharing under Firefox. Separate options are required
+# for Chrome.
+jitsi_meet_desktop_sharing_firefox_ext_id: 'null'
+jitsi_meet_desktop_sharing_firefox_disabled: true
+jitsi_meet_desktop_sharing_firefox_max_version_ext_required: '-1'
+
 # These debconf settings represent answers to interactive prompts during installation
 # of the jitsi-meet deb package. If you use custom SSL certs, you may have to set more options.
 jitsi_meet_debconf_settings:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,13 +40,12 @@ jitsi_meet_disable_third_party_requests: true
 jitsi_meet_desktop_sharing_chrome_method: 'ext'
 jitsi_meet_desktop_sharing_chrome_ext_id: 'diibjkoicjeejcmhdnailmkgecihlobk'
 
-# Path to local file on disk, for copying to target host. The remote filename
-# will be the basename of the path provided here. Optional.
+# Path to local extension on disk, for copying to target host. The remote filename
+# will be the basename of the path provided here.
 jitsi_meet_desktop_sharing_chrome_extension_filename: ''
 
 # Screensharing config for Firefox. Set max_version to '42' and disabled to 'false'
-# if you want to use screensharing under Firefox. Separate options are required
-# for Chrome.
+# if you want to use screensharing under Firefox.
 jitsi_meet_desktop_sharing_firefox_ext_id: 'null'
 jitsi_meet_desktop_sharing_firefox_disabled: true
 jitsi_meet_desktop_sharing_firefox_max_version_ext_required: '-1'

--- a/tasks/browser_extensions.yml
+++ b/tasks/browser_extensions.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy Chrome web browser extension.
+  copy:
+    src: "{{ jitsi_meet_desktop_sharing_chrome_extension_filename }}"
+    dest: "/usr/share/jitsi-meet/{{ jitsi_meet_desktop_sharing_chrome_extension_filename | basename }}"
+  notify: restart nginx
+  when: jitsi_meet_desktop_sharing_chrome_extension_filename is defined and
+        jitsi_meet_desktop_sharing_chrome_extension_filename != ''

--- a/tasks/browser_extensions.yml
+++ b/tasks/browser_extensions.yml
@@ -6,3 +6,13 @@
   notify: restart nginx
   when: jitsi_meet_desktop_sharing_chrome_extension_filename is defined and
         jitsi_meet_desktop_sharing_chrome_extension_filename != ''
+
+- name: Display URL for downloading Chrome web browser extension.
+  debug:
+    msg: >-
+      Installed Chrome web extension. Participants who wish to share
+      their screens in Jitsi Meet must download the extension from
+      'https://{{ jitsi_meet_server_name }}/{{ jitsi_meet_desktop_sharing_chrome_extension_filename | basename }}',
+      then drag-and-drop onto the chrome://extensions page.
+  when: jitsi_meet_desktop_sharing_chrome_extension_filename is defined and
+        jitsi_meet_desktop_sharing_chrome_extension_filename != ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,13 @@
 
 - include: nginx.yml
 
-- include: browser_extensions.yml
-
 - include: clean_up_default_configs.yml
   when: jitsi_meet_ssl_cert_path != '' and
         jitsi_meet_ssl_key_path != ''
 
 - include: ufw.yml
   when: jitsi_meet_configure_firewall == true
+
+  # Placing the browser extensions last so the associated debugging tasks
+  # that display URLs are visible near the end of the play.
+- include: browser_extensions.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,8 @@
 
 - include: nginx.yml
 
+- include: browser_extensions.yml
+
 - include: clean_up_default_configs.yml
   when: jitsi_meet_ssl_cert_path != '' and
         jitsi_meet_ssl_key_path != ''

--- a/templates/jitsi_meet_config.js.j2
+++ b/templates/jitsi_meet_config.js.j2
@@ -21,9 +21,9 @@ var config = {
     //defaultSipNumber: '', // Default SIP number
 
     // Desktop sharing method. Can be set to 'ext', 'webrtc' or false to disable.
-    desktopSharingChromeMethod: 'ext',
+    desktopSharingChromeMethod: '{{ jitsi_meet_desktop_sharing_chrome_method }}',
     // The ID of the jidesha extension for Chrome.
-    desktopSharingChromeExtId: 'diibjkoicjeejcmhdnailmkgecihlobk',
+    desktopSharingChromeExtId: '{{ jitsi_meet_desktop_sharing_chrome_ext_id }}',
     // The media sources to use when using screen sharing with the Chrome
     // extension.
     desktopSharingChromeSources: ['screen', 'window'],

--- a/templates/jitsi_meet_config.js.j2
+++ b/templates/jitsi_meet_config.js.j2
@@ -32,15 +32,15 @@ var config = {
 
     // The ID of the jidesha extension for Firefox. If null, we assume that no
     // extension is required.
-    desktopSharingFirefoxExtId: null,
+    desktopSharingFirefoxExtId: {{ jitsi_meet_desktop_sharing_firefox_ext_id }},
     // Whether desktop sharing should be disabled on Firefox.
-    desktopSharingFirefoxDisabled: true,
+    desktopSharingFirefoxDisabled: {{ 'true' if jitsi_meet_desktop_sharing_firefox_disabled else 'false' }},
     // The maximum version of Firefox which requires a jidesha extension.
     // Example: if set to 41, we will require the extension for Firefox versions
     // up to and including 41. On Firefox 42 and higher, we will run without the
     // extension.
     // If set to -1, an extension will be required for all versions of Firefox.
-    desktopSharingFirefoxMaxVersionExtRequired: -1,
+    desktopSharingFirefoxMaxVersionExtRequired: {{ jitsi_meet_desktop_sharing_firefox_max_version_ext_required }},
     // The URL to the Firefox extension for desktop sharing.
     desktopSharingFirefoxExtensionURL: null,
 


### PR DESCRIPTION
The browser extension for Chrome must be built separately from this role, then referenced in a variable to copy to the target host. README now includes a URL to the Jitsi Meet Jidesha documentation on building extensions.

The official docs state that Firefox support is also possible, but that hasn't been tested yet. This PR provides sufficient feature coverage to move forward with testing Chrome support, as described in #18.