### PR TITLE
Generates separate OpenSSL keypair for Prosody

### DIFF
--- a/tasks/clean_up_default_configs.yml
+++ b/tasks/clean_up_default_configs.yml
@@ -26,9 +26,12 @@
   # duplicating the config line.
 - name: Remove default localhost Nginx config file.
   file:
-    path: /etc/nginx/sites-available/localhost.conf
+    path: "{{ item }}"
     state: absent
   notify: restart nginx
+  with_items:
+    - /etc/nginx/sites-available/localhost.conf
+    - /etc/nginx/sites-enabled/localhost.conf
   # Only remove the "localhost" file if we're using custom SSL keys, i.e. in prod.
   when: jitsi_meet_ssl_cert_path != '' and
         jitsi_meet_ssl_key_path != ''

--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -17,22 +17,23 @@
     src: "/etc/prosody/conf.avail/{{ jitsi_meet_server_name }}.cfg.lua"
   notify: restart prosody
 
-- name: Create Prosody config dir for Jicofo auth info.
-  file:
-    path: /var/lib/prosody/{{ 'auth%2e'+jitsi_meet_server_name | replace('.', '%2e') }}/accounts/
-    state: directory
-    owner: prosody
-    group: prosody
-    mode: "0750"
-
-- name: Register Jicofo user with Prosody service.
-  template:
-    src: prosody_focus_auth.j2
+- name: Register jicofo agent with Prosody service.
+  command: >
+    prosodyctl register focus auth.{{ jitsi_meet_server_name }} {{ jitsi_meet_jicofo_password }}
+  args:
     # Yes, prosody actually URL-escapes the directory name for some reason.
-    dest: /var/lib/prosody/{{ 'auth%2e'+jitsi_meet_server_name | replace('.', '%2e') }}/accounts/focus.dat
-    owner: prosody
-    group: prosody
-    mode: "0640"
+    # Must hardcode the escaping in the prefix, since the replace filter only
+    # applies to the server name var, not the concatenated string.
+    creates: /var/lib/prosody/{{ 'auth%2e'+jitsi_meet_server_name | replace('.', '%2e') }}/accounts/focus.dat
+  notify:
+    - restart jicofo
+    - restart prosody
+
+- name: Generate SSL keypair for Prosody service.
+  shell: >
+    yes '' | prosodyctl cert generate {{ jitsi_meet_server_name }}
+  args:
+    creates: /var/lib/prosody/{{ jitsi_meet_server_name }}.crt
   notify:
     - restart jicofo
     - restart prosody

--- a/templates/prosody_config.j2
+++ b/templates/prosody_config.j2
@@ -15,7 +15,8 @@ VirtualHost "auth.{{ jitsi_meet_server_name }}"
     authentication = "internal_plain"
 
 Component "conference.{{ jitsi_meet_server_name }}" "muc"
-     admins = { "focus@auth.{{ jitsi_meet_server_name }}" }
+
+admins = { "focus@auth.{{ jitsi_meet_server_name }}" }
 
 Component "jitsi-videobridge.{{ jitsi_meet_server_name }}"
      component_secret = "{{ jitsi_meet_videobridge_secret }}"


### PR DESCRIPTION
The role was previously referencing an FQDN-based keypair in the Prosody config template that wasn't automatically generated by the role. Fortunately the maintainers ship `prosodyctl` which has a subcommand for generating certs appropriately—let's use that, skipping if the cert already exists.

Separately, fixes a whitespace error that caused the `admins` dict in the Prosody config to be uninitialized (see b7c4a8b). Also cleans up the default "localhost" nginx site symlink, if installing with prod certs for Nginx.

Closes #11.