### PR TITLE
Removes reference to nonexistent handler

### DIFF
--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -13,14 +13,12 @@
     - 22
     - 80
     - 443
-  notify: reload ufw
 
 - name: Open UDP port 10000 for jitsi-videobridge
   ufw:
     rule: allow
     port: 10000
     proto: udp
-  notify: reload ufw
 
 - name: Ensure UFW is running.
   ufw:


### PR DESCRIPTION
'reload ufw' is not part of `handlers/main.yml`. The reason why is because it's a non-functional command anyway, UFW rules are applied immediately by the Ansible module.

Fixes:
```
TASK [ansible-role-jitsi-meet : Open UDP port 10000 for jitsi-videobridge] *****
ERROR! The requested handler 'reload ufw' was not found in the main handlers list
```