### PR TITLE
Uses stable apt repository by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .molecule/
+.vagrant/
 .kitchen/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@ jitsi_meet_server_name: "{{ ansible_fqdn if jitsi_meet_ssl_cert_path else 'local
 # Only "anonymous" auth is supported, which lets anyone use the videoconference server.
 jitsi_meet_authentication: anonymous
 
+# Whether to use nightly builds of the Jitsi Meet components.
+jitsi_meet_use_nightly_apt_repo: false
+
 # The Debian package installation of jitsi-meet will generate secrets for the components.
 # The role will read the config file and preserve the secrets even while templating.
 # If you wish to generate your own secrets and use those, override these vars, but make

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,10 @@ jitsi_meet_authentication: anonymous
 
 # Whether to use nightly builds of the Jitsi Meet components.
 jitsi_meet_use_nightly_apt_repo: false
+jitsi_meet_apt_repo_stable: 'deb http://download.jitsi.org/ stable/'
+jitsi_meet_apt_repo_unstable: 'deb http://download.jitsi.org/nightly/deb unstable/'
+# Wrapper for dynamically determining apt repo based on boolean for stable/unstable.
+jitsi_meet_apt_repo: "{{ jitsi_meet_apt_repo_unstable if jitsi_meet_use_nightly_apt_repo else jitsi_meet_apt_repo_stable }}"
 
 # The Debian package installation of jitsi-meet will generate secrets for the components.
 # The role will read the config file and preserve the secrets even while templating.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,10 @@
 jitsi_meet_ssl_cert_path: ''
 jitsi_meet_ssl_key_path: ''
 
+jitsi_meet_base_packages:
+  - apt-transport-https
+  - default-jre-headless
+
 # Without SSL, "localhost" is the correct default. If SSL info is provided,
 # then we'll need a real domain name. Using Ansible's inferred FQDN, but you
 # can set the variable value explicitly if you use a shorter hostname
@@ -15,8 +19,8 @@ jitsi_meet_authentication: anonymous
 
 # Whether to use nightly builds of the Jitsi Meet components.
 jitsi_meet_use_nightly_apt_repo: false
-jitsi_meet_apt_repo_stable: 'deb http://download.jitsi.org/ stable/'
-jitsi_meet_apt_repo_unstable: 'deb http://download.jitsi.org/nightly/deb unstable/'
+jitsi_meet_apt_repo_stable: 'deb https://download.jitsi.org/ stable/'
+jitsi_meet_apt_repo_unstable: 'deb https://download.jitsi.org/nightly/deb unstable/'
 # Wrapper for dynamically determining apt repo based on boolean for stable/unstable.
 jitsi_meet_apt_repo: "{{ jitsi_meet_apt_repo_unstable if jitsi_meet_use_nightly_apt_repo else jitsi_meet_apt_repo_stable }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,14 +22,9 @@ jitsi_meet_use_nightly_apt_repo: false
 
 jitsi_meet_apt_repos:
   stable:
-    key_id: 66A9CD0595D6AFA247290D3BEF8B479E2DC1389C
-    key_url: "https://download.jitsi.org/jitsi-key.gpg.key"
     repo_url: 'deb https://download.jitsi.org/ stable/'
-
   unstable:
-    key_id: 040F57608F84BAF1BF844A62C697D823EB0AB654
-    key_url: None
-    repo_url: 'deb https://download.jitsi.org/nightly/deb unstable/'
+    repo_url: 'deb https://download.jitsi.org unstable/'
 
 # The Debian package installation of jitsi-meet will generate secrets for the components.
 # The role will read the config file and preserve the secrets even while templating.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,10 +19,17 @@ jitsi_meet_authentication: anonymous
 
 # Whether to use nightly builds of the Jitsi Meet components.
 jitsi_meet_use_nightly_apt_repo: false
-jitsi_meet_apt_repo_stable: 'deb https://download.jitsi.org/ stable/'
-jitsi_meet_apt_repo_unstable: 'deb https://download.jitsi.org/nightly/deb unstable/'
-# Wrapper for dynamically determining apt repo based on boolean for stable/unstable.
-jitsi_meet_apt_repo: "{{ jitsi_meet_apt_repo_unstable if jitsi_meet_use_nightly_apt_repo else jitsi_meet_apt_repo_stable }}"
+
+jitsi_meet_apt_repos:
+  stable:
+    key_id: 66A9CD0595D6AFA247290D3BEF8B479E2DC1389C
+    key_url: "https://download.jitsi.org/jitsi-key.gpg.key"
+    repo_url: 'deb https://download.jitsi.org/ stable/'
+
+  unstable:
+    key_id: 040F57608F84BAF1BF844A62C697D823EB0AB654
+    key_url: None
+    repo_url: 'deb https://download.jitsi.org/nightly/deb unstable/'
 
 # The Debian package installation of jitsi-meet will generate secrets for the components.
 # The role will read the config file and preserve the secrets even while templating.

--- a/examples/test.yml
+++ b/examples/test.yml
@@ -1,5 +1,12 @@
 ---
-- name: Test jitsi-meet role
-  hosts: all
+- name: Test jitsi-meet role (stable repo)
+  hosts: jitsi-meet-stable
   roles:
     - role: ansible-role-jitsi-meet
+      jitsi_meet_use_nightly_apt_repo: false
+
+- name: Test jitsi-meet role (unstable repo)
+  hosts: jitsi-meet-unstable
+  roles:
+    - role: ansible-role-jitsi-meet
+      jitsi_meet_use_nightly_apt_repo: true

--- a/examples/test.yml
+++ b/examples/test.yml
@@ -2,11 +2,11 @@
 - name: Test jitsi-meet role (stable repo)
   hosts: jitsi-meet-stable
   roles:
-    - role: ansible-role-jitsi-meet
+    - role: ../ansible-role-jitsi-meet
       jitsi_meet_use_nightly_apt_repo: false
 
 - name: Test jitsi-meet role (unstable repo)
   hosts: jitsi-meet-unstable
   roles:
-    - role: ansible-role-jitsi-meet
+    - role: ../ansible-role-jitsi-meet
       jitsi_meet_use_nightly_apt_repo: true

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,9 +1,13 @@
 ---
 ansible:
   playbook: examples/test.yml
+  verbose: vv
 
 molecule:
   serverspec_dir: spec/
+
+verifier:
+    name: serverspec
 
 vagrant:
   platforms:
@@ -19,14 +23,11 @@ vagrant:
 
   instances:
     - name: jitsi-meet-stable
-      options:
-        raw_config_args:
-          - "vm.network 'forwarded_port', guest: 443, host: 4443"
-          - "vm.synced_folder './', '/vagrant', disabled: true"
+      raw_config_args:
+        - "vm.network 'forwarded_port', guest: 443, host: 4443"
+        - "vm.synced_folder './', '/vagrant', disabled: true"
 
     - name: jitsi-meet-unstable
-      options:
-        raw_config_args:
-          - "vm.network 'forwarded_port', guest: 443, host: 4444"
-          - "vm.synced_folder './', '/vagrant', disabled: true"
-
+      raw_config_args:
+        - "vm.network 'forwarded_port', guest: 443, host: 4444"
+        - "vm.synced_folder './', '/vagrant', disabled: true"

--- a/molecule.yml
+++ b/molecule.yml
@@ -2,6 +2,9 @@
 ansible:
   playbook: examples/test.yml
 
+molecule:
+  serverspec_dir: spec/
+
 vagrant:
   platforms:
     - name: jessie64
@@ -15,11 +18,15 @@ vagrant:
       type: virtualbox
 
   instances:
-    - name: jitsi-meet
-      interfaces:
-        - network_name: private_network
-          type: dhcp
-          auto_config: true
+    - name: jitsi-meet-stable
       options:
         raw_config_args:
           - "vm.network 'forwarded_port', guest: 443, host: 4443"
+          - "vm.synced_folder './', '/vagrant', disabled: true"
+
+    - name: jitsi-meet-unstable
+      options:
+        raw_config_args:
+          - "vm.network 'forwarded_port', guest: 443, host: 4444"
+          - "vm.synced_folder './', '/vagrant', disabled: true"
+

--- a/spec/apt_repo_spec.rb
+++ b/spec/apt_repo_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe package('apt-transport-https') do
+  it { should be_installed }
+end
+
+describe command('apt-cache policy') do
+  jitsi_apt_repo = <<APT_REPO
+ 500 https://download.jitsi.org/ stable/ Packages
+     release o=jitsi.org,a=stable,n=stable,l=Jitsi Debian packages repository,c=
+     origin download.jitsi.org
+APT_REPO
+  its('stdout') { should include(jitsi_apt_repo) }
+end
+
+describe file('/etc/apt/sources.list.d/jitsi_meet.list') do
+  it { should exist }
+  its('mode') { should eq '644' }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+end

--- a/spec/apt_repo_spec.rb
+++ b/spec/apt_repo_spec.rb
@@ -35,6 +35,11 @@ pub   1024D/EB0AB654 2008-06-20
 uid                  SIP Communicator (Debian package) <deb-pkg@sip-communicator.org>
 sub   2048g/F6EFCE13 2008-06-20
 APT_KEY_UNWANTED
-  its('stdout') { should include(jitsi_apt_key) }
-  its('stdout') { should_not include(jitsi_apt_key_incorrect) }
+  if ENV['TARGET_HOST'].end_with?('unstable')
+    its('stdout') { should_not include(jitsi_apt_key) }
+    its('stdout') { should include(jitsi_apt_key_incorrect) }
+  else
+    its('stdout') { should include(jitsi_apt_key) }
+    its('stdout') { should_not include(jitsi_apt_key_incorrect) }
+  end
 end

--- a/spec/apt_repo_spec.rb
+++ b/spec/apt_repo_spec.rb
@@ -5,12 +5,23 @@ describe package('apt-transport-https') do
 end
 
 describe command('apt-cache policy') do
-  jitsi_apt_repo = <<APT_REPO
+  jitsi_apt_repo_stable = <<APT_REPO_STABLE
  500 https://download.jitsi.org/ stable/ Packages
      release o=jitsi.org,a=stable,n=stable,l=Jitsi Debian packages repository,c=
      origin download.jitsi.org
-APT_REPO
-  its('stdout') { should include(jitsi_apt_repo) }
+APT_REPO_STABLE
+  jitsi_apt_repo_unstable = <<APT_REPO_UNSTABLE
+ 500 https://download.jitsi.org/ unstable/ Packages
+     release o=jitsi.org,a=unstable,n=unstable,l=Jitsi Debian packages repository,c=
+     origin download.jitsi.org
+APT_REPO_UNSTABLE
+  if ENV['TARGET_HOST'].end_with?('unstable')
+    its('stdout') { should include(jitsi_apt_repo_unstable) }
+    its('stdout') { should_not include(jitsi_apt_repo_stable) }
+  else
+    its('stdout') { should include(jitsi_apt_repo_stable) }
+    its('stdout') { should_not include(jitsi_apt_repo_unstable) }
+  end
 end
 
 describe file('/etc/apt/sources.list.d/jitsi_meet.list') do
@@ -35,11 +46,6 @@ pub   1024D/EB0AB654 2008-06-20
 uid                  SIP Communicator (Debian package) <deb-pkg@sip-communicator.org>
 sub   2048g/F6EFCE13 2008-06-20
 APT_KEY_UNWANTED
-  if ENV['TARGET_HOST'].end_with?('unstable')
-    its('stdout') { should_not include(jitsi_apt_key) }
-    its('stdout') { should include(jitsi_apt_key_incorrect) }
-  else
-    its('stdout') { should include(jitsi_apt_key) }
-    its('stdout') { should_not include(jitsi_apt_key_incorrect) }
-  end
+  its('stdout') { should include(jitsi_apt_key) }
+  its('stdout') { should_not include(jitsi_apt_key_incorrect) }
 end

--- a/spec/apt_repo_spec.rb
+++ b/spec/apt_repo_spec.rb
@@ -19,3 +19,22 @@ describe file('/etc/apt/sources.list.d/jitsi_meet.list') do
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
 end
+
+describe command('apt-key finger') do
+  jitsi_apt_key = <<APT_KEY
+pub   4096R/2DC1389C 2016-06-23
+      Key fingerprint = 66A9 CD05 95D6 AFA2 4729  0D3B EF8B 479E 2DC1 389C
+uid                  Jitsi <dev@jitsi.org>
+sub   4096R/88D3172B 2016-06-23
+APT_KEY
+
+  # TODO: Perhaps this key still refers to unstable repo?
+  jitsi_apt_key_incorrect = <<APT_KEY_UNWANTED
+pub   1024D/EB0AB654 2008-06-20
+      Key fingerprint = 040F 5760 8F84 BAF1 BF84  4A62 C697 D823 EB0A B654
+uid                  SIP Communicator (Debian package) <deb-pkg@sip-communicator.org>
+sub   2048g/F6EFCE13 2008-06-20
+APT_KEY_UNWANTED
+  its('stdout') { should include(jitsi_apt_key) }
+  its('stdout') { should_not include(jitsi_apt_key_incorrect) }
+end

--- a/spec/jicofo_spec.rb
+++ b/spec/jicofo_spec.rb
@@ -9,8 +9,10 @@ describe file('/etc/jitsi/jicofo/config') do
   its('content') { should match(/^JICOFO_PORT=5347$/) }
   # The regex for the "secret" may be off. Tests have failed before
   # when matching only '\w', due to a '@', so adding that.
-  its('content') { should match(/^JICOFO_SECRET=[\w@]{8,}$/) }
-  its('content') { should match(/^JICOFO_AUTH_PASSWORD=\w{8,}$/) }
+  # Also have seen '#', so adding that. Would love a definitive
+  # take on which characters are allowed here.
+  its('content') { should match(/^JICOFO_SECRET=[\w@#]{8,}$/) }
+  its('content') { should match(/^JICOFO_AUTH_PASSWORD=[\w@#]{8,}$/) }
   its('content') { should match(/^JICOFO_AUTH_USER=focus$/) }
 end
 

--- a/spec/prosody_spec.rb
+++ b/spec/prosody_spec.rb
@@ -7,24 +7,21 @@ describe file('/etc/prosody/conf.avail/localhost.cfg.lua') do
   its('mode') { should eq '644' }
 
   its('content') do
-    should contain(
-      'VirtualHost "localhost"').before(
-        'authentication = "anonymous"')
+    should contain('VirtualHost "localhost"')
+      .before('authentication = "anonymous"')
   end
 
   wanted_enabled_modules = %w(bosh pubsub ping)
   wanted_enabled_modules.each do |enabled_module|
     its('content') do
-      should contain(
-        enabled_module.to_s).from(
-          /^\s+modules_enabled = \{/).to(
-            /^\s+\}$/)
+      should contain(enabled_module.to_s)
+        .from(/^\s+modules_enabled = \{/)
+        .to(/^\s+\}$/)
     end
   end
   its('content') do
-    should contain(
-      'VirtualHost "auth.localhost"').before(
-        'authentication = "internal_plain"')
+    should contain('VirtualHost "auth.localhost"')
+      .before('authentication = "internal_plain"')
   end
 
   wanted_config_line_pairs = {

--- a/spec/prosody_spec.rb
+++ b/spec/prosody_spec.rb
@@ -56,7 +56,7 @@ describe file('/etc/prosody/conf.avail/localhost.cfg.lua') do
     it { should be_owned_by 'prosody' }
     it { should be_grouped_into 'prosody' }
     its('mode') { should eq '640' }
-    regexp = /^\s+\["password"\] = "\w+";$/
+    regexp = /^\s+\["password"\] = "[\w@#]+";$/
     its('content') { should match(regexp) }
   end
 end

--- a/spec/ufw_spec.rb
+++ b/spec/ufw_spec.rb
@@ -4,7 +4,6 @@ ufw_expected_rules = [
   %r{ 22/tcp + ALLOW IN +Anywhere},
   %r{ 80/tcp + ALLOW IN +Anywhere},
   %r{ 443/tcp + ALLOW IN +Anywhere},
-  %r{ 4443/tcp + ALLOW IN +Anywhere},
   %r{ 10000/udp + ALLOW IN +Anywhere}
 ]
 

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -9,15 +9,20 @@
     keyserver: keys.gnupg.net
     id: C697D823EB0AB654
 
-- name: Install Jitsi apt repo (stable)
-  apt_repository:
-    repo: 'deb http://download.jitsi.org/ stable/'
-    state: "{{ 'absent' if jitsi_meet_use_nightly_apt_repo else 'present' }}"
+# Prior versions of the role were writing to this file, let's
+# clean it up and use a generalized filename for configuring the apt repo,
+# regardless of whether stable or unstable is used.
+- name: Remove deprecated repo filename.
+  file:
+    path: /etc/apt/sources.list.d/download_jitsi_org_nightly_deb.list
+    state: absent
 
-- name: Install Jitsi apt repo (unstable)
+- name: Install Jitsi apt repo.
   apt_repository:
-    repo: 'deb http://download.jitsi.org/nightly/deb unstable/'
-    state: "{{ 'present' if jitsi_meet_use_nightly_apt_repo else 'absent' }}"
+    repo: "{{ jitsi_meet_apt_repo }}"
+    state: present
+    # Ansible will automatically add the ".list" suffix.
+    filename: /etc/apt/sources.list.d/jitsi_meet
 
 - name: Install Jitsi Meet
   apt:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -9,10 +9,15 @@
     keyserver: keys.gnupg.net
     id: C697D823EB0AB654
 
-- name: Install Jitsi apt repo
+- name: Install Jitsi apt repo (stable)
+  apt_repository:
+    repo: 'deb http://download.jitsi.org/ stable/'
+    state: "{{ 'absent' if jitsi_meet_use_nightly_apt_repo else 'present' }}"
+
+- name: Install Jitsi apt repo (unstable)
   apt_repository:
     repo: 'deb http://download.jitsi.org/nightly/deb unstable/'
-    state: present
+    state: "{{ 'present' if jitsi_meet_use_nightly_apt_repo else 'absent' }}"
 
 - name: Install Jitsi Meet
   apt:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -3,6 +3,8 @@
   apt:
     name: "{{ item }}"
     state: present
+    update_cache: yes
+    cache_valid_time: 3600
   with_items: "{{ jitsi_meet_base_packages }}"
 
 # Prior versions of the role were writing to this file, let's

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,10 +5,22 @@
     state: present
   with_items: "{{ jitsi_meet_base_packages }}"
 
-- name: Add signing key for Jitsi repository
+- name: Add signing key for Jitsi repository.
   apt_key:
     keyserver: keys.gnupg.net
-    id: C697D823EB0AB654
+    id: "{{ item.id }}"
+    url: "{{ item.url }}"
+    state: "{{ item.state }}"
+  with_items:
+    - id: 66A9CD0595D6AFA247290D3BEF8B479E2DC1389C
+      state: present
+      url: "https://download.jitsi.org/jitsi-key.gpg.key"
+
+    # Prior versions of the role installed a Debian SIP Communicator
+    # apt GPG key, which is no longer correct.
+    - id: 040F57608F84BAF1BF844A62C697D823EB0AB654
+      state: absent
+      url: None
 
 # Prior versions of the role were writing to this file, let's
 # clean it up and use a generalized filename for configuring the apt repo,

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -19,13 +19,12 @@
   set_fact:
     jitsi_strategy: "{{ 'unstable' if jitsi_meet_use_nightly_apt_repo else 'stable' }}"
 
+# Both stable and unstable repos use the same signing key.
 - name: Configure signing key for Jitsi repository.
   apt_key:
-    keyserver: keys.gnupg.net
-    id: "{{ item.value.key_id }}"
-    url: "{{ item.value.key_url }}"
-    state: "{{ 'present' if jitsi_strategy == item.key else 'absent' }}"
-  with_dict: "{{ jitsi_meet_apt_repos }}"
+    id: 66A9CD0595D6AFA247290D3BEF8B479E2DC1389C
+    url: "https://download.jitsi.org/jitsi-key.gpg.key"
+    state: present
 
 - name: Install Jitsi apt repo.
   apt_repository:
@@ -38,8 +37,9 @@
 - name: Install Jitsi Meet
   apt:
     name: jitsi-meet
-    state: present
+    state: latest
     update_cache: yes
+    cache_valid_time: 3600
 
 - name: Set debconf options for jitsi-meet.
   debconf:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,8 +1,9 @@
 ---
-- name: Install Java JRE
+- name: Install base apt packages.
   apt:
-    name: default-jre-headless
+    name: "{{ item }}"
     state: present
+  with_items: "{{ jitsi_meet_base_packages }}"
 
 - name: Add signing key for Jitsi repository
   apt_key:

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,23 +5,6 @@
     state: present
   with_items: "{{ jitsi_meet_base_packages }}"
 
-- name: Add signing key for Jitsi repository.
-  apt_key:
-    keyserver: keys.gnupg.net
-    id: "{{ item.id }}"
-    url: "{{ item.url }}"
-    state: "{{ item.state }}"
-  with_items:
-    - id: 66A9CD0595D6AFA247290D3BEF8B479E2DC1389C
-      state: present
-      url: "https://download.jitsi.org/jitsi-key.gpg.key"
-
-    # Prior versions of the role installed a Debian SIP Communicator
-    # apt GPG key, which is no longer correct.
-    - id: 040F57608F84BAF1BF844A62C697D823EB0AB654
-      state: absent
-      url: None
-
 # Prior versions of the role were writing to this file, let's
 # clean it up and use a generalized filename for configuring the apt repo,
 # regardless of whether stable or unstable is used.
@@ -30,12 +13,25 @@
     path: /etc/apt/sources.list.d/download_jitsi_org_nightly_deb.list
     state: absent
 
+- name: Determine repo strategy.
+  set_fact:
+    jitsi_strategy: "{{ 'unstable' if jitsi_meet_use_nightly_apt_repo else 'stable' }}"
+
+- name: Configure signing key for Jitsi repository.
+  apt_key:
+    keyserver: keys.gnupg.net
+    id: "{{ item.value.key_id }}"
+    url: "{{ item.value.key_url }}"
+    state: "{{ 'present' if jitsi_strategy == item.key else 'absent' }}"
+  with_dict: "{{ jitsi_meet_apt_repos }}"
+
 - name: Install Jitsi apt repo.
   apt_repository:
-    repo: "{{ jitsi_meet_apt_repo }}"
-    state: present
+    repo: "{{ item.value.repo_url }}"
+    state: "{{ 'present' if jitsi_strategy == item.key else 'absent' }}"
     # Ansible will automatically add the ".list" suffix.
     filename: /etc/apt/sources.list.d/jitsi_meet
+  with_dict: "{{ jitsi_meet_apt_repos }}"
 
 - name: Install Jitsi Meet
   apt:


### PR DESCRIPTION
The Jitsi Meet project offers both stable and nightly builds via apt repository. These changes update the default role behavior to use the stable apt repos, but still support using the nightly repos if the churn is preferred.

Includes a few updates to test suite, as well—these changes should be tested fully prior to merge.
