### PR TITLE
Makes Nginx configuration optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ jitsi_meet_debconf_settings:
 # Role will automatically install configure ufw with jitsi-meet port holes.
 # If you're managing a firewall elsewise, set this to false, and ufw will be skipped.
 jitsi_meet_configure_firewall: true
+
+# Role will automatically install nginx and configure a vhost for use with jitsi-meet.
+# If you prefer to manage web vhosts via a separate role, set this to false.
+jitsi_meet_configure_nginx: true
 ```
 
 Screen sharing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,3 +87,7 @@ jitsi_meet_debconf_settings:
 # Role will automatically install configure ufw with jitsi-meet port holes.
 # If you're managing a firewall elsewise, set this to false, and ufw will be skipped.
 jitsi_meet_configure_firewall: true
+
+# Role will automatically install nginx and configure a vhost for use with jitsi-meet.
+# If you prefer to manage web vhosts via a separate role, set this to false.
+jitsi_meet_configure_nginx: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
 - include: jicofo.yml
 
 - include: nginx.yml
+  when: jitsi_meet_configure_nginx
 
 - include: clean_up_default_configs.yml
   when: jitsi_meet_ssl_cert_path != '' and


### PR DESCRIPTION
The role provides the sane default of a preconfigured Nginx vhost,
created following the Jitsi Meet project docs. That's fine for a
baseline configuration, but makes managing for the Jitsi service via
a separate role quite difficult. Let's make the Nginx configuration
opt-out, so it still runs by default but can be skipped if admins
prefer another method for managing vhosts.

The vhost template still ships with the role and should be consulted
when writing a custom vhost config.

Closes #28.