### PR TITLE
Manages SIP Communicator config lines

### DIFF
--- a/tasks/jitsi_meet.yml
+++ b/tasks/jitsi_meet.yml
@@ -23,7 +23,6 @@
     # the jitsi-meet postinst scripts, so these values must match.
     path: /usr/share/jitsi-videobridge/.sip-communicator
     owner: jvb
-    group: jvb
   notify: restart jitsi-videobridge
 
 - name: Write SIP communicator settings.
@@ -31,5 +30,4 @@
     dest: /usr/share/jitsi-videobridge/.sip-communicator/sip-communicator.properties
     content: "org.jitsi.impl.neomedia.transform.srtp.SRTPCryptoContext.checkReplay=false"
     owner: jvb
-    group: jvb
   notify: restart jitsi-videobridge

--- a/tasks/jitsi_meet.yml
+++ b/tasks/jitsi_meet.yml
@@ -15,3 +15,21 @@
     line: ".level={{ jitsi_meet_videobridge_loglevel }}"
     state: present
   notify: restart jitsi-videobridge
+
+- name: Create directory for SIP communicator settings.
+  file:
+    state: directory
+    # Hard-coding homedir path and username because they're configured via
+    # the jitsi-meet postinst scripts, so these values must match.
+    path: /usr/share/jitsi-videobridge/.sip-communicator
+    owner: jvb
+    group: jvb
+  notify: restart jitsi-videobridge
+
+- name: Write SIP communicator settings.
+  copy:
+    dest: /usr/share/jitsi-videobridge/.sip-communicator/sip-communicator.properties
+    content: "org.jitsi.impl.neomedia.transform.srtp.SRTPCryptoContext.checkReplay=false"
+    owner: jvb
+    group: jvb
+  notify: restart jitsi-videobridge


### PR DESCRIPTION
Updates the role to provide the SIP communicator config line recommended
in the official install guide.

Closes #29.