### PR TITLE
Finalizes making Nginx config optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ jitsi_meet_ssl_key_path: ''
 # Without SSL, "localhost" is the correct default. If SSL info is provided,
 # then we'll need a real domain name. Using Ansible's inferred FQDN, but you
 # can set the variable value explicitly if you use a shorter hostname
-jitsi_meet_server_name: "{{ ansible_fqdn if jitsi_meet_ssl_cert_path else 'localhost' }}"
+# If automatic Nginx configuration is disabled, also use FQDN, since presumably
+# another role will manage the vhost config.
+jitsi_meet_server_name: "{{ ansible_fqdn if (jitsi_meet_ssl_cert_path or not jitsi_meet_configure_nginx) else 'localhost' }}"
 
 # Only "anonymous" auth is supported, which lets anyone use the videoconference server.
 jitsi_meet_authentication: anonymous

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,9 @@ jitsi_meet_base_packages:
 # Without SSL, "localhost" is the correct default. If SSL info is provided,
 # then we'll need a real domain name. Using Ansible's inferred FQDN, but you
 # can set the variable value explicitly if you use a shorter hostname
-jitsi_meet_server_name: "{{ ansible_fqdn if jitsi_meet_ssl_cert_path else 'localhost' }}"
+# If automatic Nginx configuration is disabled, also use FQDN, since presumably
+# another role will manage the vhost config.
+jitsi_meet_server_name: "{{ ansible_fqdn if (jitsi_meet_ssl_cert_path or not jitsi_meet_configure_nginx) else 'localhost' }}"
 
 # Only "anonymous" auth is supported, which lets anyone use the videoconference server.
 jitsi_meet_authentication: anonymous

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,10 @@
   when: jitsi_meet_configure_nginx
 
 - include: clean_up_default_configs.yml
-  when: jitsi_meet_ssl_cert_path != '' and
-        jitsi_meet_ssl_key_path != ''
+  when: (jitsi_meet_ssl_cert_path != '' and
+         jitsi_meet_ssl_key_path != '') or
+         not jitsi_meet_configure_nginx
+
 
 - include: ufw.yml
   when: jitsi_meet_configure_firewall == true


### PR DESCRIPTION
Supplements the changes introduced in #30. The logic for determining the
hostname (either 'localhost' or FQDN) needed to be updated to choose
FQDN if the role tasks for configuring Nginx are disabled.