### PR TITLE
Moves the port 5347 checks to the prosody spec file.

### DIFF
--- a/spec/jicofo_spec.rb
+++ b/spec/jicofo_spec.rb
@@ -29,18 +29,7 @@ describe service('jicofo') do
   it { should be_running }
 end
 
-describe port(5347) do
-  it { should be_listening }
-  it { should be_listening.on('127.0.0.1') }
-  it { should_not be_listening.on('0.0.0.0') }
-end
-
 # Check that jicofo process is running as jicofo user
 describe command('pgrep -u jicofo | wc -l') do
   its('stdout') { should eq "1\n" }
-end
-
-describe command('sudo netstat -nlt') do
-  its('stdout') { should match(/127\.0\.0\.1:5347/) }
-  its('stdout') { should_not match(/0\.0\.0\.0:5347/) }
 end

--- a/spec/prosody_spec.rb
+++ b/spec/prosody_spec.rb
@@ -60,3 +60,16 @@ describe file('/etc/prosody/conf.avail/localhost.cfg.lua') do
     its('content') { should match(regexp) }
   end
 end
+
+# 5347 is the XMPP component port.
+# Prosody listens on it, jicofo and jitsi-videobridge connect.
+describe port(5347) do
+  it { should be_listening }
+  it { should be_listening.on('127.0.0.1') }
+  it { should_not be_listening.on('0.0.0.0') }
+end
+
+describe command('sudo netstat -nlt') do
+  its('stdout') { should match(/127\.0\.0\.1:5347/) }
+  its('stdout') { should_not match(/0\.0\.0\.0:5347/) }
+end

--- a/spec/videobridge_spec.rb
+++ b/spec/videobridge_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-# This is actually the port for the "jicofo" service; the jitsi-meet manual
-# install docs aren't explicit about default ports. FWIW, the config file
-# for jvb says that the default port is "5275", but I suspect that's old info.
+# This is the port which jvb will use to connect to prosody
 jvb_service_port = 5347
 
 describe file('/etc/jitsi/videobridge/config') do
@@ -31,18 +29,7 @@ describe service('jitsi-videobridge') do
   it { should be_running }
 end
 
-describe port(jvb_service_port) do
-  it { should be_listening }
-  it { should be_listening.on('127.0.0.1') }
-  it { should_not be_listening.on('0.0.0.0') }
-end
-
 # Check that jicofo process is running as jicofo user
 describe command('pgrep -u jicofo | wc -l') do
   its('stdout') { should eq "1\n" }
-end
-
-describe command('sudo netstat -nlt') do
-  its('stdout') { should match(/127\.0\.0\.1:#{jvb_service_port}/) }
-  its('stdout') { should_not match(/0\.0\.0\.0:#{jvb_service_port}/) }
 end


### PR DESCRIPTION
The check for port 5347 was duplicated in the jicofo and the videobridge spec files. It seems best suited for the prosody spec file, since prosody is the process which binds on the port.